### PR TITLE
解决编号后不换行的问题

### DIFF
--- a/hhu-thesis/setup/set-bachelor.typ
+++ b/hhu-thesis/setup/set-bachelor.typ
@@ -4,7 +4,7 @@
 #let set-bachelor(always-new-page: true, doc) = {
   set page(paper: "a4", margin: (top: 2.7cm, bottom: 3cm, left: 3.2cm, right: 3.2cm))
   set text(font: ziti.宋体, size: zihao.小四, weight: "regular", lang: "zh")
-  set par(first-line-indent: 2em, leading: 1.2em, justify: true)
+  set par(first-line-indent: (amount: 2em, all: true), leading: 1.2em, justify: true)
 
   set enum(numbering: it  => {
     v(0.125em)


### PR DESCRIPTION
目前版本中使用编号后不会换行，例如：
```typst
+ 测试

测试
```
结果为：
![image](https://github.com/user-attachments/assets/a2fcdb42-de61-4936-9b72-fe520d203248)
更改后：
![image](https://github.com/user-attachments/assets/de105ea7-94f1-4e89-acd4-7906bdae15c4)
目前没有发现此更改会导致其他bug