### PR TITLE
Flexible blanks

### DIFF
--- a/hhu-thesis/parts/title-page-conf.typ
+++ b/hhu-thesis/parts/title-page-conf.typ
@@ -1,4 +1,4 @@
-#import "../utils/utils.typ": fakebold, ziti, zihao, chineseunderline, fieldname
+#import "../utils/utils.typ": fakebold, ziti, zihao, chineseunderline, fieldname, fit-in,  label-content-grid
 
 // 中文封面配置
 #let title-cn-conf(
@@ -51,21 +51,21 @@
         dy: 2cm,
         dx: -2cm,
         {
-          set text(
-            font: ziti.黑体,
-            size: zihao.五号,
-            weight: "regular",
-            lang: "zh",
-            region: "cn",
-          )
-          set align(center)
-          grid(
-            columns: (2em, 8em),
-            row-gutter: 1.2em,
-            "学号",
-            chineseunderline(author.ID),
-            "年级",
-            chineseunderline(author.YEAR),
+          label-content-grid(
+            (
+              ("学号", author.ID),
+              ("年级", author.YEAR),
+            ),
+            align: center,
+            row-gutter: 15pt,
+            spliter-width: 3pt,
+            min-content-width: 80pt,
+            label-style: (content) => {
+              text(font: ziti.黑体, size: zihao.五号, weight: "regular")[#fit-in(content)]
+            },
+            content-style: (content) => {
+              text(font: ziti.黑体, size: zihao.五号, weight: "regular")[#chineseunderline(content)]
+            },
           )
         },
       )
@@ -100,18 +100,30 @@
           set text(font: ziti.宋体, size: zihao.小三, weight: "regular")
           set underline(offset: 5pt)
           set place(dy: -0.2em, center)
-          grid(
-            columns: (5em, 0.2em, 10em),
+          label-content-grid(
+            (
+              ("专业", major),
+              ("姓名", author.CN),
+              ("指导教师", advisors.CN),
+              ("评阅人", reader),
+            ),
+            align: center,
             row-gutter: 1.5em,
-            fieldname([专#h(2em)业], bold: true), "", place(chineseunderline(major)),
-            fieldname([姓#h(2em)名], bold: true), "", place(chineseunderline(author.CN)),
-            fieldname([指导教师], bold: true), "", place(chineseunderline(advisors.CN)),
-            fieldname([评#h(0.5em)阅#h(0.5em)人], bold: true), "", place(chineseunderline(reader)),
+            spliter-width: 0.2em,
+            min-label_width: 4em,
+            min-content-width: 10em,
+            label-style: (content) => {
+              text(font: ziti.黑体, size: zihao.小三, weight: "bold")[#fit-in(content)]
+            },
+            content-style: (content) => {
+              [#chineseunderline(content)]
+            },
           )
         },
         // 空间
         [],
         // 日期和地点
+        
         grid(
           rows: 2,
           gutter: 16pt,  // 可以调整行间距
@@ -182,17 +194,22 @@
 
     v(3cm)
 
-    set text(font: ziti.宋体, size: zihao.小三, weight: "regular")
+    set text(font: ziti.宋体, size: zihao.四号, weight: "regular")
     set align(center)
-    grid(
-      columns: (10em, 1em, 10em),
-      row-gutter: 1.5em,
-      fieldname([College]), ":", align(left, school.EN),
-      fieldname([Subject]), ":", align(left, subject),
-      fieldname([Name]), ":", align(left, author.EN),
-      fieldname([Directed by]), ":", align(left, advisors.EN),
-    )
-
+    label-content-grid(
+      (
+        ("College", school.EN),
+        ("Subject", subject),
+        ("Name", author.EN),
+        ("Directed by", advisors.EN),
+      ),
+        align: (right, center, left),
+        row-gutter: 1.5em,
+        spliter: ":",
+        spliter-width: 1em,
+        min-label_width: 0em,
+        min-content-width: 8em,
+      )
     v(1cm)
 
     block(text(font: "Times New Roman", size: zihao.小二, weight: "regular", "NANJING CHINA"))

--- a/hhu-thesis/template.typ
+++ b/hhu-thesis/template.typ
@@ -105,7 +105,7 @@
   ),
   school: (
     CN: "河海大学",
-    EN: "Hohai University",
+    EN: "College of Hydrology and Water Resources, Hohai University",
   ),
   major: "自动化",
   reader: "李四 副教授",

--- a/init-files/thesis.typ
+++ b/init-files/thesis.typ
@@ -1,4 +1,4 @@
-#import "@preview/shane-hhu-thesis:0.3.0": bachelor-conf, thanks, appendix, code
+#import "../hhu-thesis/template.typ": bachelor-conf, thanks, appendix, code
 
 // #import "../hhu-thesis/template.typ": bachelor-conf, thanks, appendix, code
 
@@ -27,12 +27,12 @@
   ),
   school: (
     CN: "河海大学",
-    EN: "Hohai University",
+    EN: "College of Hydrology and Water Resources,Hohai University",
   ),
   form: "thesis", // 毕业论文："thesis"，毕业设计："design", 课程报告："report"
   major: "自动化",
   subject: "subject",
-  reader: "李四 副教授",
+  reader: "李四 副教授\n李五 教授",
   date: "二〇二四年五月",
   cn-abstract: [
     由于泥沙与水流的相互作用，使得河流发生演变，因此泥沙特性与水流特性均是河流动力学的重要研究课题。当水流中含有植物时，水流的紊动特性会发生明显的改变，从而引起泥沙的一些特性如沉速发生改变。本文以实验为基础，结合理论分析，研究了在静水条件下刚性植物对泥沙沉速的影响，同时在水槽中通过改变流量来研究在恒定均匀流条件下非淹没植物对泥沙沉降轨迹的影响，得到如下主要结论：


### PR DESCRIPTION
提供了更加灵活的label-content框。
支持自适应长度和手动换行。
例如，
![image](https://github.com/user-attachments/assets/b791344a-11e1-4b19-8f85-c151fccfaf89)
（评阅人 = "李四 副教授\n李五 教授"）
![image](https://github.com/user-attachments/assets/8807cf10-a166-4066-a01e-7d80a5e2c501)
（College = "College of Hydrology and Water Resources,\nHohai University"）
